### PR TITLE
Support proper semantic versioning

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,41 +30,40 @@
  */
 
 var VERSIONS = {
-  BASE:                   { api: 1,     ndk: 0, semver: "1.0",   name: "(no code name)",     versionCode: "BASE" },
-  BASE_1_1:               { api: 2,     ndk: 0, semver: "1.1",   name: "(no code name)",     versionCode: "BASE_1_1" },
-  CUPCAKE:                { api: 3,     ndk: 1, semver: "1.5",   name: "Cupcake",            versionCode: "CUPCAKE" },
-  DONUT:                  { api: 4,     ndk: 2, semver: "1.6",   name: "Donut",              versionCode: "DONUT" },
-  ECLAIR:                 { api: 5,     ndk: 2, semver: "2.0",   name: "Eclair",             versionCode: "ECLAIR" },
-  ECLAIR_0_1:             { api: 6,     ndk: 2, semver: "2.0.1", name: "Eclair",             versionCode: "ECLAIR_0_1" },
-  ECLAIR_MR1:             { api: 7,     ndk: 3, semver: "2.1",   name: "Eclair",             versionCode: "ECLAIR_MR1" },
-  FROYO:                  { api: 8,     ndk: 4, semver: "2.2",   name: "Froyo",              versionCode: "FROYO" },
-  GINGERBREAD:            { api: 9,     ndk: 5, semver: "2.3",   name: "Gingerbread",        versionCode: "GINGERBREAD" },
-  GINGERBREAD_MR1:        { api: 10,    ndk: 5, semver: "2.3.3", name: "Gingerbread",        versionCode: "GINGERBREAD_MR1" },
-  HONEYCOMB:              { api: 11,    ndk: 5, semver: "3.0",   name: "Honeycomb",          versionCode: "HONEYCOMB" },
-  HONEYCOMB_MR1:          { api: 12,    ndk: 6, semver: "3.1",   name: "Honeycomb",          versionCode: "HONEYCOMB_MR1" },
-  HONEYCOMB_MR2:          { api: 13,    ndk: 6, semver: "3.2",   name: "Honeycomb",          versionCode: "HONEYCOMB_MR2" },
-  ICE_CREAM_SANDWICH:     { api: 14,    ndk: 7, semver: "4.0",   name: "Ice Cream Sandwich", versionCode: "ICE_CREAM_SANDWICH" },
-  ICE_CREAM_SANDWICH_MR1: { api: 15,    ndk: 8, semver: "4.0.3", name: "Ice Cream Sandwich", versionCode: "ICE_CREAM_SANDWICH_MR1" },
-  JELLY_BEAN:             { api: 16,    ndk: 8, semver: "4.1",   name: "Jellybean",          versionCode: "JELLY_BEAN" },
-  JELLY_BEAN_MR1:         { api: 17,    ndk: 8, semver: "4.2",   name: "Jellybean",          versionCode: "JELLY_BEAN_MR1" },
-  JELLY_BEAN_MR2:         { api: 18,    ndk: 8, semver: "4.3",   name: "Jellybean",          versionCode: "JELLY_BEAN_MR2" },
-  KITKAT:                 { api: 19,    ndk: 8, semver: "4.4",   name: "KitKat",             versionCode: "KITKAT" },
-  KITKAT_WATCH:           { api: 20,    ndk: 8, semver: "4.4",   name: "KitKat Watch",       versionCode: "KITKAT_WATCH" },
-  LOLLIPOP:               { api: 21,    ndk: 8, semver: "5.0",   name: "Lollipop",           versionCode: "LOLLIPOP" },
-  LOLLIPOP_MR1:           { api: 22,    ndk: 8, semver: "5.1",   name: "Lollipop",           versionCode: "LOLLIPOP_MR1" },
-  M:                      { api: 23,    ndk: 8, semver: "6.0",   name: "Marshmallow",        versionCode: "M" },
-  N:                      { api: 24,    ndk: 8, semver: "7.0",   name: "Nougat",             versionCode: "N" },
-  N_MR1:                  { api: 25,    ndk: 8, semver: "7.1",   name: "Nougat",             versionCode: "N_MR1" },
-  O:                      { api: 26,    ndk: 8, semver: "8.0.0", name: "Oreo",               versionCode: "O" }
+  BASE:                   { api: 1,     ndk: 0, semver: "1.0",               name: "(no code name)",     versionCode: "BASE" },
+  BASE_1_1:               { api: 2,     ndk: 0, semver: "1.1",               name: "(no code name)",     versionCode: "BASE_1_1" },
+  CUPCAKE:                { api: 3,     ndk: 1, semver: "1.5",               name: "Cupcake",            versionCode: "CUPCAKE" },
+  DONUT:                  { api: 4,     ndk: 2, semver: "1.6",               name: "Donut",              versionCode: "DONUT" },
+  ECLAIR:                 { api: 5,     ndk: 2, semver: "2.0",               name: "Eclair",             versionCode: "ECLAIR" },
+  ECLAIR_0_1:             { api: 6,     ndk: 2, semver: "2.0.1",             name: "Eclair",             versionCode: "ECLAIR_0_1" },
+  ECLAIR_MR1:             { api: 7,     ndk: 3, semver: "2.1",               name: "Eclair",             versionCode: "ECLAIR_MR1" },
+  FROYO:                  { api: 8,     ndk: 4, semver: "2.2.x",             name: "Froyo",              versionCode: "FROYO" },
+  GINGERBREAD:            { api: 9,     ndk: 5, semver: "2.3.0 - 2.3.2",     name: "Gingerbread",        versionCode: "GINGERBREAD" },
+  GINGERBREAD_MR1:        { api: 10,    ndk: 5, semver: "2.3.3 - 2.3.7",     name: "Gingerbread",        versionCode: "GINGERBREAD_MR1" },
+  HONEYCOMB:              { api: 11,    ndk: 5, semver: "3.0",               name: "Honeycomb",          versionCode: "HONEYCOMB" },
+  HONEYCOMB_MR1:          { api: 12,    ndk: 6, semver: "3.1",               name: "Honeycomb",          versionCode: "HONEYCOMB_MR1" },
+  HONEYCOMB_MR2:          { api: 13,    ndk: 6, semver: "3.2.x",             name: "Honeycomb",          versionCode: "HONEYCOMB_MR2" },
+  ICE_CREAM_SANDWICH:     { api: 14,    ndk: 7, semver: "4.0.1 - 4.0.2",     name: "Ice Cream Sandwich", versionCode: "ICE_CREAM_SANDWICH" },
+  ICE_CREAM_SANDWICH_MR1: { api: 15,    ndk: 8, semver: "4.0.3 - 4.0.4",     name: "Ice Cream Sandwich", versionCode: "ICE_CREAM_SANDWICH_MR1" },
+  JELLY_BEAN:             { api: 16,    ndk: 8, semver: "4.1.x",             name: "Jellybean",          versionCode: "JELLY_BEAN" },
+  JELLY_BEAN_MR1:         { api: 17,    ndk: 8, semver: "4.2.x",             name: "Jellybean",          versionCode: "JELLY_BEAN_MR1" },
+  JELLY_BEAN_MR2:         { api: 18,    ndk: 8, semver: "4.3.x",             name: "Jellybean",          versionCode: "JELLY_BEAN_MR2" },
+  KITKAT:                 { api: 19,    ndk: 8, semver: "4.4.0 - 4.4.4",     name: "KitKat",             versionCode: "KITKAT" },
+  KITKAT_WATCH:           { api: 20,    ndk: 8, semver: "4.4",               name: "KitKat Watch",       versionCode: "KITKAT_WATCH" },
+  LOLLIPOP:               { api: 21,    ndk: 8, semver: "5.0",               name: "Lollipop",           versionCode: "LOLLIPOP" },
+  LOLLIPOP_MR1:           { api: 22,    ndk: 8, semver: "5.1",               name: "Lollipop",           versionCode: "LOLLIPOP_MR1" },
+  M:                      { api: 23,    ndk: 8, semver: "6.0",               name: "Marshmallow",        versionCode: "M" },
+  N:                      { api: 24,    ndk: 8, semver: "7.0",               name: "Nougat",             versionCode: "N" },
+  N_MR1:                  { api: 25,    ndk: 8, semver: "7.1",               name: "Nougat",             versionCode: "N_MR1" },
+  O:                      { api: 26,    ndk: 8, semver: "8.0.0",             name: "Oreo",               versionCode: "O" }
 }
 
-// This altSemVer accomodates the variations of semantic versions in the table above.
-// For instance, Oreo is 8.0.0 while N is 7.0, searching for "8.0" or "8.0.0" will
-// return Oreo, or searching for "7.0" or "7.0.0" will return N. "2.2.0" will return Froyo.
-function getAlternateSemVer(semver) {
-  if (semver.match(/\d+.\d+.0/)) {
-    return semver.replace(/.\d+$/, '')
-  } else if (semver.match(/^\d+.\d+$/)) {
+var semver = require('semver');
+
+// semver format requires <major>.<minor>.<patch> but we allow just <major>.<minor> format.
+// Coerce <major>.<minor> to <major>.<minor>.0
+function formatSemver(semver) {
+  if (semver.match(/^\d+.\d+$/)) {
     return semver + '.0'
   } else {
     return semver
@@ -82,9 +81,10 @@ function getFromDefaultPredicate(arg) {
       return true
     }
 
-    // Compare semver and alternate semver (see above).
-    var altSemVer = getAlternateSemVer(arg)
-    if (version.semver === arg || version.semver === altSemVer) {
+    let argSemver = formatSemver(arg);
+    let versionSemver = formatSemver(version.semver);
+
+    if (semver.valid(argSemver) && semver.satisfies(argSemver, versionSemver)) {
       return true
     }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "docs": "jsdoc index.js -d ./docs/ -R README.md --debug",
     "jshint": "jshint ."
   },
-  "dependencies": {},
+  "dependencies": {
+    "semver": "^5.4.1"
+  },
   "devDependencies": {
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.2",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -54,6 +54,33 @@ test('get version by semantic version', (t) => {
   t.equal(android.get("2.3.3").versionCode, android.GINGERBREAD_MR1.versionCode)
 })
 
+test('support version ranges', (t) => {
+  t.plan(7);
+  t.equal(android.get("4.4").versionCode, android.KITKAT.versionCode);
+  t.equal(android.get("4.4.0").versionCode, android.KITKAT.versionCode);
+  t.equal(android.get("4.4.1").versionCode, android.KITKAT.versionCode);
+  t.equal(android.get("4.4.2").versionCode, android.KITKAT.versionCode);
+  t.equal(android.get("4.4.3").versionCode, android.KITKAT.versionCode);
+  t.equal(android.get("4.4.4").versionCode, android.KITKAT.versionCode);
+  t.equal(android.get("4.4.5"), null);
+})
+
+test('support x-ranges', (t) => {
+  t.plan(12);
+  t.equal(android.get("4.1").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.0").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.1").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.2").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.3").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.4").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.5").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.6").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.7").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.8").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.9").versionCode, android.JELLY_BEAN.versionCode);
+  t.equal(android.get("4.1.10").versionCode, android.JELLY_BEAN.versionCode);
+});
+
 test('access version codes object', (t) => {
   t.plan(1)
   t.ok(android.VERSIONS)


### PR DESCRIPTION
The actual versions are specified as semantic versions. For example, KitKat is 4.4 - 4.4.4. Prior to this change, entering any one of 4.4.1 - 4.4.4 would return null (when KitKat is expected).

This change uses the node semver module for validating if a version string satisfies any of the release semantic versions.

I've added a couple of test cases to verify that x-ranges (e.g 4.1.x) will be correctly satisfied, as well as version ranges (e.g 4.4 - 4.4.4).