### PR TITLE
Introduce new Android SDK level 27 (Oreo 8.1.0).

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ var VERSIONS = {
   M:                      { api: 23,    ndk: 8, semver: "6.0",               name: "Marshmallow",        versionCode: "M" },
   N:                      { api: 24,    ndk: 8, semver: "7.0",               name: "Nougat",             versionCode: "N" },
   N_MR1:                  { api: 25,    ndk: 8, semver: "7.1",               name: "Nougat",             versionCode: "N_MR1" },
-  O:                      { api: 26,    ndk: 8, semver: "8.0.0",             name: "Oreo",               versionCode: "O" }
+  O:                      { api: 26,    ndk: 8, semver: "8.0.0",             name: "Oreo",               versionCode: "O" },
+  O_MR1:                  { api: 27,    ndk: 8, semver: "8.1.0",             name: "Oreo",               versionCode: "O_MR1" }
 }
 
 var semver = require('semver');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -43,7 +43,7 @@ test('getAll versions by predicate', (t) => {
   actual = android.getAll((version) => {
     return version.api > 22
   }).map((version) => version.versionCode)
-  t.deepEqual(actual, ["M", "N", "N_MR1", "O"])
+  t.deepEqual(actual, ["M", "N", "N_MR1", "O", "O_MR1"])
 })
 
 test('get version by semantic version', (t) => {
@@ -87,7 +87,7 @@ test('access version codes object', (t) => {
 })
 
 test('access specific versions directly', (t) => {
-  t.plan(26)
+  t.plan(27)
   t.ok(android.BASE)
   t.ok(android.BASE_1_1)
   t.ok(android.CUPCAKE)
@@ -114,4 +114,5 @@ test('access specific versions directly', (t) => {
   t.ok(android.N)
   t.ok(android.N_MR1)
   t.ok(android.O)
+  t.ok(android.O_MR1)
 })


### PR DESCRIPTION
Add SDK 27, version 8.1.0 (codename Oreo) to the known versions and
update associated tests, per the following updates/resources:

* https://android-developers.googleblog.com/2017/12/welcoming-android-81-oreo-and-android.html
* https://source.android.com/setup/build-numbers#platform-code-names-versions-api-levels-and-ndk-releases
* https://developer.android.com/reference/android/os/Build.VERSION_CODES.html#O_MR1

This was more critical prior to https://github.com/apache/cordova-android/commit/109112ae752dcd2641a320b3451c992f57916170, but it still seems like this should be updated since API version 27 seems to be the default install for Android Studio, thus potentially creating a problem for new (at least, to my awareness) Cordova users.

Not sure if this is everything necessary, but thought I'd make an attempt at a contribution.  Happy to adjust accordingly.!